### PR TITLE
feat(auth): azure auth with custom token provider

### DIFF
--- a/InfisicalConfiguration.Tests/InfisicalConfiguration.Tests.csproj
+++ b/InfisicalConfiguration.Tests/InfisicalConfiguration.Tests.csproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Identity" Version="1.13.2" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />

--- a/InfisicalConfiguration/InfisicalAuthConfig.cs
+++ b/InfisicalConfiguration/InfisicalAuthConfig.cs
@@ -12,15 +12,42 @@ public class UniversalAuthCredentials
   }
 }
 
+
+public class AzureCustomProviderAuthOptions
+{
+  public string IdentityId { get; set; } = string.Empty;
+  public Func<Task<string>> TokenProvider { get; set; } = null!;
+}
+
+public class AzureCustomProviderAuthCredentials
+{
+  public string IdentityId { get; private set; }
+  public Func<Task<string>> TokenProvider { get; private set; }
+
+  public AzureCustomProviderAuthCredentials(string identityId, Func<Task<string>> tokenProvider)
+  {
+    if (string.IsNullOrEmpty(identityId))
+    {
+      throw new ArgumentNullException(nameof(identityId));
+    }
+
+    IdentityId = identityId;
+    TokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+  }
+}
+
 public enum InfisicalAuthType
 {
   Universal,
+  AzureCustomProvider,
 }
 
 public class InfisicalAuth
 {
   private InfisicalAuthType AuthType { get; set; }
   private UniversalAuthCredentials? universalAuthCredentials;
+  private AzureCustomProviderAuthCredentials? azureCustomProviderAuthCredentials;
+
 
   internal InfisicalAuth() { }
 
@@ -44,10 +71,31 @@ public class InfisicalAuth
     throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetUniversalAuth?");
   }
 
+  public AzureCustomProviderAuthCredentials GetAzureCustomProviderAuth()
+  {
+    if (azureCustomProviderAuthCredentials == null)
+    {
+      throw new InvalidOperationException("Azure auth must be set");
+    }
+
+    if (AuthType == InfisicalAuthType.AzureCustomProvider)
+    {
+      return azureCustomProviderAuthCredentials;
+    }
+
+    throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetAzureCustomProviderAuth?");
+  }
+
   internal void SetUniversalAuthCredentials(UniversalAuthCredentials credentials)
   {
     universalAuthCredentials = credentials;
     AuthType = InfisicalAuthType.Universal;
+  }
+
+  internal void SetAzureCustomProviderAuthCredentials(AzureCustomProviderAuthCredentials credentials)
+  {
+    azureCustomProviderAuthCredentials = credentials;
+    AuthType = InfisicalAuthType.AzureCustomProvider;
   }
 }
 
@@ -66,20 +114,53 @@ public class InfisicalAuthBuilder
     return this;
   }
 
+  public InfisicalAuthBuilder SetAzureCustomProviderAuth(Action<AzureCustomProviderAuthOptions> configure)
+  {
+    var options = new AzureCustomProviderAuthOptions();
+    configure(options);
+
+    if (string.IsNullOrEmpty(options.IdentityId))
+    {
+      throw new InvalidOperationException("IdentityId must be set");
+    }
+
+    if (options.TokenProvider == null)
+    {
+      throw new InvalidOperationException("TokenProvider must be set");
+    }
+
+    _auth.SetAzureCustomProviderAuthCredentials(new AzureCustomProviderAuthCredentials(options.IdentityId, options.TokenProvider));
+    return this;
+  }
+
   public InfisicalAuth Build()
   {
     var auth = _auth;
-    if (auth.GetAuthMethod() == InfisicalAuthType.Universal)
+    switch (auth.GetAuthMethod())
     {
-      var universalAuth = auth.GetUniversalAuth();
-      if (string.IsNullOrEmpty(universalAuth.ClientId) || string.IsNullOrEmpty(universalAuth.ClientSecret))
-      {
-        throw new InvalidOperationException("ClientId and ClientSecret must be set");
-      }
-    }
-    else
-    {
-      throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetUniversalAuth?");
+      case InfisicalAuthType.Universal:
+        var universalAuth = auth.GetUniversalAuth();
+        if (string.IsNullOrEmpty(universalAuth.ClientId) || string.IsNullOrEmpty(universalAuth.ClientSecret))
+        {
+          throw new InvalidOperationException("ClientId and ClientSecret must be set");
+        }
+        break;
+      case InfisicalAuthType.AzureCustomProvider:
+        var azureCustomProviderAuth = auth.GetAzureCustomProviderAuth();
+        if (string.IsNullOrEmpty(azureCustomProviderAuth.IdentityId))
+        {
+          throw new InvalidOperationException("IdentityId must be set");
+        }
+        if (azureCustomProviderAuth.TokenProvider == null)
+        {
+          throw new InvalidOperationException("TokenProvider must be set");
+        }
+
+        azureCustomProviderAuth.TokenProvider().Wait();
+
+        break;
+      default:
+        throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetUniversalAuth or SetAzureCustomProviderAuth?");
     }
 
     return auth;

--- a/InfisicalConfiguration/InfisicalAuthConfig.cs
+++ b/InfisicalConfiguration/InfisicalAuthConfig.cs
@@ -12,13 +12,6 @@ public class UniversalAuthCredentials
   }
 }
 
-
-public class AzureCustomProviderAuthOptions
-{
-  public string IdentityId { get; set; } = string.Empty;
-  public Func<Task<string>> TokenProvider { get; set; } = null!;
-}
-
 public class AzureCustomProviderAuthCredentials
 {
   public string IdentityId { get; private set; }
@@ -114,22 +107,19 @@ public class InfisicalAuthBuilder
     return this;
   }
 
-  public InfisicalAuthBuilder SetAzureCustomProviderAuth(Action<AzureCustomProviderAuthOptions> configure)
+  public InfisicalAuthBuilder SetAzureCustomProviderAuth(string identityId, Func<Task<string>> tokenProvider)
   {
-    var options = new AzureCustomProviderAuthOptions();
-    configure(options);
-
-    if (string.IsNullOrEmpty(options.IdentityId))
+    if (string.IsNullOrEmpty(identityId))
     {
       throw new InvalidOperationException("IdentityId must be set");
     }
 
-    if (options.TokenProvider == null)
+    if (tokenProvider == null)
     {
       throw new InvalidOperationException("TokenProvider must be set");
     }
 
-    _auth.SetAzureCustomProviderAuthCredentials(new AzureCustomProviderAuthCredentials(options.IdentityId, options.TokenProvider));
+    _auth.SetAzureCustomProviderAuthCredentials(new AzureCustomProviderAuthCredentials(identityId, tokenProvider));
     return this;
   }
 
@@ -155,8 +145,6 @@ public class InfisicalAuthBuilder
         {
           throw new InvalidOperationException("TokenProvider must be set");
         }
-
-        azureCustomProviderAuth.TokenProvider().Wait();
 
         break;
       default:

--- a/InfisicalConfiguration/InfisicalAuthConfig.cs
+++ b/InfisicalConfiguration/InfisicalAuthConfig.cs
@@ -76,7 +76,7 @@ public class InfisicalAuth
       return azureCustomProviderAuthCredentials;
     }
 
-    throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetAzureCustomProviderAuth?");
+    throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetAzureAuth?");
   }
 
   internal void SetUniversalAuthCredentials(UniversalAuthCredentials credentials)
@@ -85,7 +85,7 @@ public class InfisicalAuth
     AuthType = InfisicalAuthType.Universal;
   }
 
-  internal void SetAzureCustomProviderAuthCredentials(AzureCustomProviderAuthCredentials credentials)
+  internal void SetAzureAuthCredentials(AzureCustomProviderAuthCredentials credentials)
   {
     azureCustomProviderAuthCredentials = credentials;
     AuthType = InfisicalAuthType.AzureCustomProvider;
@@ -107,7 +107,7 @@ public class InfisicalAuthBuilder
     return this;
   }
 
-  public InfisicalAuthBuilder SetAzureCustomProviderAuth(string identityId, Func<Task<string>> tokenProvider)
+  public InfisicalAuthBuilder SetAzureAuth(string identityId, Func<Task<string>> tokenProvider)
   {
     if (string.IsNullOrEmpty(identityId))
     {
@@ -119,7 +119,7 @@ public class InfisicalAuthBuilder
       throw new InvalidOperationException("TokenProvider must be set");
     }
 
-    _auth.SetAzureCustomProviderAuthCredentials(new AzureCustomProviderAuthCredentials(identityId, tokenProvider));
+    _auth.SetAzureAuthCredentials(new AzureCustomProviderAuthCredentials(identityId, tokenProvider));
     return this;
   }
 
@@ -148,7 +148,7 @@ public class InfisicalAuthBuilder
 
         break;
       default:
-        throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetUniversalAuth or SetAzureCustomProviderAuth?");
+        throw new InvalidOperationException("AuthType must be set. Are you missing a call to SetUniversalAuth or SetAzureAuth?");
     }
 
     return auth;

--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ The equivalent of this JSON would be a secret in Infisical with the key `CONNNEC
 
 
 ### InfisicalAuthBuilder Setters
-**SetUniversalAuth*()**
+
+#### SetUniversalAuth()
 - `clientId` (string): The client ID of your universal auth machine identity.
 - `clientSecret` (string): The client secret of your universal auth machine identity.
+
+#### SetAzureAuth()
+- `identityId` (string): The ID of the identity you wish to authenticate with.
+- `tokenProvider` (function): The function that will be called to retrieve your Entra ID authentication token. The authentication token will be used to authenticate against Infisical with.
+
+
+##### Example usage:
+
+The following example assumes that you are logged into Visual Studio with your Entra account. The identity used for authentication must have the same Tenet ID as the directory that you are logged into in Visual Studio.
+
+Instead of using `VisualStudioCredential()`, you can also use the following token providers.
+- `AzureCliCredential()`: Fetches Entra credentials from the CLI
+- `VisualStudioCodeCredential()`: Fetches Entra credentials from Visual Studio Code.
+- `DefaultAzureCredential()`: Tries to fetch Entra credentials from multiple sources on your machine. Sources include Environment variables, Managed identity credentials, Azure CLI, PowerShell, Visual Studio, Visual Studio Code, and more. You can read more [here].(https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet)
+
+```csharp
+.SetAuth(
+  new InfisicalAuthBuilder()
+    .SetAzureAuth("<identity-id>", async () =>
+      {
+        var vsCredential = new VisualStudioCredential();
+
+        // Get JWT token from Visual Studio
+        var token = await vsCredential.GetTokenAsync(
+            new TokenRequestContext(
+                ["https://management.azure.com/.default"]
+            ),
+            CancellationToken.None
+        );
+
+        // JWT token can be used to authenticate with Infisical
+        return token.Token;
+      }
+    ).Build()
+)
+
+

--- a/infisical-dotnet-configuration.sln
+++ b/infisical-dotnet-configuration.sln
@@ -3,7 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfisicalConfiguration", "InfisicalConfiguration\InfisicalConfiguration.csproj", "{7A5009D6-FDD5-7E8A-BD92-E2086568E4F9}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfisicalConfiguration.Tests", "InfisicalConfiguration.Tests\InfisicalConfiguration.Tests.csproj", "{F0060438-8BA1-47F4-9532-AA9BEC0BFDC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfisicalConfiguration.Tests", "InfisicalConfiguration.Tests\InfisicalConfiguration.Tests.csproj", "{BFB9CE6F-ACC3-0ABE-34DF-9DA5BB3BE763}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,11 +16,15 @@ Global
 		{7A5009D6-FDD5-7E8A-BD92-E2086568E4F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A5009D6-FDD5-7E8A-BD92-E2086568E4F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A5009D6-FDD5-7E8A-BD92-E2086568E4F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFB9CE6F-ACC3-0ABE-34DF-9DA5BB3BE763}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFB9CE6F-ACC3-0ABE-34DF-9DA5BB3BE763}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFB9CE6F-ACC3-0ABE-34DF-9DA5BB3BE763}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFB9CE6F-ACC3-0ABE-34DF-9DA5BB3BE763}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {FD1FAA6B-FEB2-493F-8182-F9DC07231587}
+		SolutionGuid = {FF5517E0-6941-43F9-890B-3426B9F397AB}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds Azure auth support with the use of a custom token provider. 

Example usage (macbook):
1. The user is logged into the Azure CLI (`az login`)
2. The user uses the snippet below for authenticating with Azure

Prerequisites:
1. The user must have an identity configured on Infisical
   2. The user performing the authentication below, must be a part of the same directory as the identity is configured for (Tenet ID's must match)



```csharp
.SetAuth(
                new InfisicalAuthBuilder()
                    .SetAzureAuth("<identity-id>", async () =>
                      {
                        var cliCredential = new AzureCliCredential();

                        // Get JWT token from Azure CLI
                        var token = await cliCredential.GetTokenAsync(
                            new TokenRequestContext(
                                ["https://management.azure.com/.default"]
                            ),
                            CancellationToken.None
                        );

                        // JWT token can be used to authenticate with Infisical
                        return token.Token;
                      }
                    )
                    .Build()
            )
```